### PR TITLE
Builder: Increase download timeout for slow connections

### DIFF
--- a/Builder.cs
+++ b/Builder.cs
@@ -29,14 +29,17 @@ public class Builder : Task
         var platformioChanged = !File.Exists(platformioFileLoc) ||
                                 !File.ReadAllText(platformioFileLoc).Equals(platformIoCommit);
         var webClient = new HttpClient();
+        webClient.Timeout = TimeSpan.FromMinutes(120);
         if (firmwareChanged)
         {
+            Console.WriteLine("Builder: Downloading Santroller firmware...");
             var result = webClient.GetByteArrayAsync(firmwareUrl).Result;
             File.WriteAllBytes(Path.Combine(Parameter2, "Assets", "firmware.tar.xz"), result);
             File.WriteAllText(firmwareFileLoc, firmwareCommit);
         }
 
         if (!platformioChanged) return true;
+        Console.WriteLine("Builder: Downloading SantrollerLibs...");
         var result2 = webClient.GetByteArrayAsync(platformIoUrl).Result;
         File.WriteAllBytes(Path.Combine(Parameter2, "Assets", "platformio.tar.xz"), result2);
         File.WriteAllText(platformioFileLoc, platformIoCommit);


### PR DESCRIPTION
MSBuild task Builder fails if PlatformIO (90MB) download timeouts, so dev on a slow connection cannot build the project. Also added a bit of verbosity, so the dev knows what they're waiting for